### PR TITLE
Splitted webpack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules/
 
 # Build directories
-build
+/build
 
 # Logs
 logs

--- a/config/build/buildLoaders.ts
+++ b/config/build/buildLoaders.ts
@@ -1,0 +1,13 @@
+import webpack from "webpack"
+
+export const buildLoaders = (): webpack.RuleSetRule[] => {
+    const tsLoader = {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+    }
+    
+    return [
+        tsLoader,
+    ]
+}

--- a/config/build/buildPlugins.ts
+++ b/config/build/buildPlugins.ts
@@ -1,0 +1,10 @@
+import HtmlWebpackPlugin from "html-webpack-plugin"
+import webpack from "webpack"
+import { BuildOptions } from "./types/config"
+
+export const buildPlugins = ({paths}: BuildOptions): webpack.WebpackPluginInstance[] => [
+    new HtmlWebpackPlugin({
+        template: paths.html,
+    }),
+    new webpack.ProgressPlugin()
+]

--- a/config/build/buildResolvers.ts
+++ b/config/build/buildResolvers.ts
@@ -1,0 +1,7 @@
+import { ResolveOptions } from "webpack"
+
+export const buildResolvers = (): ResolveOptions => {
+    return {
+        extensions: ['.tsx', '.ts', '.js'],
+    }
+}

--- a/config/build/buildWebpackConfig.ts
+++ b/config/build/buildWebpackConfig.ts
@@ -1,0 +1,30 @@
+import webpack from "webpack"
+import { buildLoaders } from "./buildLoaders"
+import { buildPlugins } from "./buildPlugins"
+import { buildResolvers } from "./buildResolvers"
+import {BuildOptions} from "./types/config"
+
+
+export const buildWebpackConfig = (options: BuildOptions): webpack.Configuration => {
+    const {mode, paths} = options;
+
+    return {
+        mode,
+        // entry point to the app
+        entry: paths.entry,
+        // where and how to build the app
+        output: {
+            // [contenthash] generates unique hash, if sth changed
+            filename: '[name].[contenthash].js',
+            path: paths.build,
+            // clean output folder
+            clean: true
+        },
+        plugins: buildPlugins(options),
+        module: {
+            rules: buildLoaders(),
+        },
+        // ./component instead of ./component.tsx
+        resolve: buildResolvers(),   
+    }
+}

--- a/config/build/types/config.ts
+++ b/config/build/types/config.ts
@@ -1,0 +1,13 @@
+export type BuildMode = "production" | "development";
+
+export interface BuildPaths {
+    entry: string;
+    build: string;
+    html: string;
+}
+
+export interface BuildOptions {
+    mode: BuildMode;
+    paths: BuildPaths;
+    isDev: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         // use imports/exports with commonjs requires
         "esModuleInterop": true,
         // default imports - "import name" instead of "import * as name"
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": "."
     },
     "ts-node": {
         "compilerOptions": {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,40 +1,22 @@
 import path from "path";
 import webpack from "webpack";
-import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { buildWebpackConfig } from "./config/build/buildWebpackConfig";
+import { BuildPaths } from "./config/build/types/config";
 
-
-const config: webpack.Configuration = {
-    mode: "development",
-    // entry point to the app
+const paths: BuildPaths = {
     entry: path.resolve(__dirname, 'src', 'index.ts'),
-    // where and how to build the app
-    output: {
-        // [contenthash] generates unique hash, if sth changed
-        filename: '[name].[contenthash].js',
-        path: path.resolve(__dirname, 'build'),
-        // clean output folder
-        clean: true
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: 'ts-loader',
-                exclude: /node_modules/,
-            },
-        ],
-    },
-    // ./component instead of ./component.tsx
-    resolve: {
-        extensions: ['.tsx', '.ts', '.js'],
-    },
-    plugins: [
-        new HtmlWebpackPlugin({
-            template: path.resolve(__dirname, 'public', 'index.html'),
-        }),
-        new webpack.ProgressPlugin()
-    ],
+    build: path.resolve(__dirname, 'build'),
+    html: path.resolve(__dirname, 'public', 'index.html')
 }
+
+const mode = "development"
+const isDev = mode === "development";
+
+const config: webpack.Configuration = buildWebpackConfig({
+    mode,
+    paths,
+    isDev
+});
 
 // changed nodejs export (module.export) to js export
 export default config;


### PR DESCRIPTION
The webpack config was splitted into the following parts:
- `buildLoaders` - returns the list of rules;
- `buildPlugins` - returns the list of plugin instances;
- `buildResolvers` - returns resolve options;
- `buildWebpackConfig` - takes options and returns webpack config;

Build options:
- mode
- isDev
- paths