### PR TITLE
Add theme: context, provider, hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
 import { Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { Route, Routes } from 'react-router-dom';
-import './index.scss'
+import './styles/index.scss'
 import { AboutPageAsync } from './pages/AboutPage/AboutPage.async';
 import { MainPageAsync } from './pages/MainPage/MainPage.async';
-
+import { useTheme } from './theme/useTheme';
 
 export const App = () => {
+  const {theme, toggleTheme} = useTheme();
+
   return (
-    <div className='app'>
+    <div className={`app ${theme}`}>
+      <button onClick={toggleTheme}>Toggle theme</button>
       <Link to={'/'}>Main</Link>
       <Link to={'/about'}>About</Link>
       <Suspense fallback={<div>Loading...</div>}>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,9 +1,0 @@
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-.app {
-    font-size: 35px;
-}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,14 @@
 import { render } from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
+import { ThemeProvider } from "./theme/ThemeProvider";
 
 
 render(
     <BrowserRouter>
-        <App />
+        <ThemeProvider>
+            <App />
+        </ThemeProvider>
     </BrowserRouter>,
     document.getElementById('root')
 )

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,13 @@
+@import "reset";
+@import "./variables/global.scss";
+@import "./themes/light.scss";
+@import "./themes/dark.scss";
+
+.app {
+    font: var(--font-m);
+
+    background: var(--bg-color);
+    color: var(--primary-color);
+    
+    min-height: 100vh;
+}

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -1,0 +1,10 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+input, button, textarea, select {
+    margin: 0;
+    font: inherit;
+}

--- a/src/styles/themes/dark.scss
+++ b/src/styles/themes/dark.scss
@@ -1,0 +1,6 @@
+.app.dark {
+    --bg-color: #090949;
+
+    --primary-color: #049604;
+    --secondary-color: #04ff04;
+}

--- a/src/styles/themes/light.scss
+++ b/src/styles/themes/light.scss
@@ -1,0 +1,6 @@
+.app.light {
+    --bg-color: #e8e8ea;
+
+    --primary-color: #0232c2;
+    --secondary-color: #0449e0;
+}

--- a/src/styles/variables/global.scss
+++ b/src/styles/variables/global.scss
@@ -1,0 +1,11 @@
+:root {
+    --font-family-main: Consolas, monaco, monospace; 
+
+    --font-size-m: 16px;
+    --font-line-m: 24px;
+    --font-m: var(--font-size-m) / var(--font-line-m) var(--font-family-main);
+
+    --font-size-l: 24px;
+    --font-line-l: 32px;
+    --font-l: var(--font-size-l) / var(--font-line-l) var(--font-family-main);
+}

--- a/src/theme/ThemeContext.ts
+++ b/src/theme/ThemeContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+
+export enum Theme {
+    LIGHT = 'light',
+    DARK = 'dark'
+}
+
+export interface ThemeContextProps {
+    theme?: Theme,
+    setTheme?: (theme: Theme) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextProps>({});
+
+export const LOCAL_STORAGE_THEME_KEY = 'theme';

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,0 +1,19 @@
+import { FC, useMemo, useState } from 'react'
+import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from './ThemeContext'
+
+const defaultTheme = localStorage.getItem(LOCAL_STORAGE_THEME_KEY) as Theme || Theme.LIGHT;
+
+export const ThemeProvider: FC = ({ children }) => {
+    const [theme, setTheme] = useState<Theme>(defaultTheme);
+
+    const defaultProps = useMemo(() => ({
+        theme,
+        setTheme
+    }), [theme])
+
+    return (
+        <ThemeContext.Provider value={defaultProps}>
+            {children}
+        </ThemeContext.Provider>
+    )
+}

--- a/src/theme/useTheme.ts
+++ b/src/theme/useTheme.ts
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from "./ThemeContext";
+
+interface UseThemeResult {
+    toggleTheme: () => void;
+    theme: Theme;
+}
+
+export const useTheme = (): UseThemeResult => {
+    const { theme, setTheme } = useContext(ThemeContext)
+
+    const toggleTheme = () => {
+        const newTheme = theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT
+        setTheme(newTheme);
+        localStorage.setItem(LOCAL_STORAGE_THEME_KEY, newTheme)
+    }
+
+    return {theme, toggleTheme};
+}


### PR DESCRIPTION
Created `ThemeContext`:
- Specified theme interface;
- Specified context props;

Added `ThemeProvider`:
- Theme is memoised by `useMemo`;
- Default theme is taken from `localStorage` or is set to `Theme.LIGHT`;

Added `useTheme` hook:
- Uses `ThemeContext`;
- Sets theme in the `localStorage`;
